### PR TITLE
fix: load claude.md on each iteration

### DIFF
--- a/internal/prd/generator.go
+++ b/internal/prd/generator.go
@@ -144,6 +144,7 @@ func runClaudeConversion(absPRDDir string) error {
 	cmd := exec.Command("claude",
 		"--dangerously-skip-permissions",
 		"--output-format", "stream-json",
+		"--verbose",
 		"-p", prompt,
 	)
 	cmd.Dir = absPRDDir

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -276,6 +276,7 @@ func NewAppWithOptions(prdPath string, maxIter int) (*App, error) {
 
 	// Create loop manager for parallel PRD execution
 	manager := loop.NewManager(maxIter)
+	manager.SetBaseDir(baseDir)
 	manager.SetConfig(cfg)
 
 	// Register the initial PRD with the manager


### PR DESCRIPTION
When no worktree is configured, `effectiveWorkDir()` falls back to the PRD directory (`.chief/prds/<name>/`) instead of the project root. Claude therefore never sees CLAUDE.md, meaning any project specific rules are silently ignored on every iteration.

The comment in manager.go even documents the intended behaviour correctly: `WorktreeDir string // Working directory for this PRD (empty = project root)`, but the implementation doesn't match.

This PR fixes that: store `baseDir` (already computed in `NewAppWithOptions`) on the manager and use it as the working directory when no worktree is set.
