### PR TITLE
Add multi-agent support (Claude, Pi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="assets/hero.png" alt="Chief" width="500">
 </p>
 
-Build big projects with Claude. Chief breaks your work into tasks and runs Claude Code in a loop until they're done.
+Build big projects with AI coding agents. Chief breaks your work into tasks and runs your chosen agent in a loop until they're done.
 
 **[Documentation](https://minicodemonkey.github.io/chief/)** · **[Quick Start](https://minicodemonkey.github.io/chief/guide/quick-start)**
 
@@ -32,19 +32,34 @@ chief new
 chief
 ```
 
-Chief runs Claude in a [Ralph Wiggum loop](https://ghuntley.com/ralph/): each iteration starts with a fresh context window, but progress is persisted between runs. This lets Claude work through large projects without hitting context limits.
+Chief runs your chosen agent in a [Ralph Wiggum loop](https://ghuntley.com/ralph/): each iteration starts with a fresh context window, but progress is persisted between runs. This lets the agent work through large projects without hitting context limits.
 
-## How It Works
+## Supported Agents
 
-1. **Describe your project** as a series of tasks
-2. **Chief runs Claude** in a loop, one task at a time
-3. **One commit per task** — clean git history, easy to review
+Chief supports multiple coding agents:
 
-See the [documentation](https://minicodemonkey.github.io/chief/concepts/how-it-works) for details.
+- **Claude Code** (default) — Anthropic's CLI agent
+- **Pi** — The Pi coding agent from badlogic
+
+### Configuration
+
+Set the agent in your project's `.chief/config.yaml`:
+
+```yaml
+agent: pi  # Use Pi instead of Claude
+```
+
+Or set via environment variable:
+
+```bash
+export CHIEF_AGENT=pi
+```
 
 ## Requirements
 
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
+- At least one supported agent installed and authenticated:
+  - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (for Claude agent)
+  - [Pi CLI](https://github.com/badlogic/pi-mono) (for Pi agent)
 
 ## License
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,112 @@
+// Package agent provides an abstraction layer for different coding agents.
+// Supported agents: Claude Code (claude), Pi (pi)
+package agent
+
+import (
+	"context"
+	"os/exec"
+)
+
+// AgentType represents the type of coding agent.
+type AgentType string
+
+const (
+	AgentClaude AgentType = "claude"
+	AgentPi     AgentType = "pi"
+)
+
+// Agent defines the interface for coding agents.
+type Agent interface {
+	// Type returns the agent type.
+	Type() AgentType
+
+	// Command returns the CLI command name.
+	Command() string
+
+	// BuildPromptArgs returns the arguments for passing a prompt.
+	BuildPromptArgs(prompt string) []string
+
+	// BuildOutputFormatArgs returns the arguments for output format.
+	BuildOutputFormatArgs(format string) []string
+
+	// RequiredFlags returns additional required flags.
+	RequiredFlags() []string
+}
+
+// Claude represents Claude Code agent.
+type Claude struct{}
+
+// Type returns the agent type.
+func (c *Claude) Type() AgentType { return AgentClaude }
+
+// Command returns the CLI command name.
+func (c *Claude) Command() string { return "claude" }
+
+// BuildPromptArgs returns the arguments for passing a prompt.
+func (c *Claude) BuildPromptArgs(prompt string) []string {
+	return []string{"-p", prompt}
+}
+
+// BuildOutputFormatArgs returns the arguments for output format.
+func (c *Claude) BuildOutputFormatArgs(format string) []string {
+	return []string{"--output-format", format}
+}
+
+// RequiredFlags returns additional required flags.
+func (c *Claude) RequiredFlags() []string {
+	return []string{"--dangerously-skip-permissions", "--verbose"}
+}
+
+// Pi represents the Pi coding agent.
+type Pi struct{}
+
+// Type returns the agent type.
+func (p *Pi) Type() AgentType { return AgentPi }
+
+// Command returns the CLI command name.
+func (p *Pi) Command() string { return "pi" }
+
+// BuildPromptArgs returns the arguments for passing a prompt.
+func (p *Pi) BuildPromptArgs(prompt string) []string {
+	return []string{"-p", prompt}
+}
+
+// BuildOutputFormatArgs returns the arguments for output format.
+// Pi uses JSON output mode differently - it supports --json for JSON output.
+func (p *Pi) BuildOutputFormatArgs(format string) []string {
+	// Pi uses --json for JSON output, but for stream-json compatibility
+	// we'll use the default output and parse accordingly
+	return []string{}
+}
+
+// RequiredFlags returns additional required flags.
+func (p *Pi) RequiredFlags() []string {
+	return []string{}
+}
+
+// NewAgent creates a new agent based on the type.
+func NewAgent(agentType AgentType) Agent {
+	switch agentType {
+	case AgentPi:
+		return &Pi{}
+	case AgentClaude:
+		fallthrough
+	default:
+		return &Claude{}
+	}
+}
+
+// BuildCommand builds the command for the given agent.
+func BuildCommand(ctx context.Context, agentType AgentType, prompt, workDir string) *exec.Cmd {
+	agent := NewAgent(agentType)
+
+	args := []string{}
+	args = append(args, agent.RequiredFlags()...)
+	args = append(args, agent.BuildPromptArgs(prompt)...)
+	args = append(args, agent.BuildOutputFormatArgs("stream-json")...)
+
+	cmd := exec.CommandContext(ctx, agent.Command(), args...)
+	cmd.Dir = workDir
+
+	return cmd
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/minicodemonkey/chief/internal/agent"
 	"gopkg.in/yaml.v3"
 )
 
@@ -11,8 +12,19 @@ const configFile = ".chief/config.yaml"
 
 // Config holds project-level settings for Chief.
 type Config struct {
-	Worktree   WorktreeConfig   `yaml:"worktree"`
+	Agent    string            `yaml:"agent"`    // Agent to use: "claude" or "pi"
+	Worktree WorktreeConfig    `yaml:"worktree"`
 	OnComplete OnCompleteConfig `yaml:"onComplete"`
+}
+
+// AgentType returns the configured agent type.
+func (c *Config) AgentType() agent.AgentType {
+	switch c.Agent {
+	case "pi":
+		return agent.AgentPi
+	default:
+		return agent.AgentClaude
+	}
 }
 
 // WorktreeConfig holds worktree-related settings.


### PR DESCRIPTION
This PR adds multi-agent support to chief, enabling different AI agents (Claude, Pi) to be used via a new agent abstraction package.

Changes:
- Added internal/agent/agent.go - new agent abstraction package
- Modified internal/loop/loop.go - uses agent interface
- Added SetAgentType/AgentType methods to internal/loop/manager.go
- Added agent field to config in internal/config/config.go
- Updated README.md documentation